### PR TITLE
Remove file dependency from overall report

### DIFF
--- a/p2p.py
+++ b/p2p.py
@@ -124,7 +124,7 @@ def main(show_past_investments):
                 df_group_by_originator = df_group_by_date_platform.groupby([marketplace.LOAN_ORIGINATOR]).sum()
                 logger.info(df_group_by_originator.sort_values(by=marketplace.OUTSTANDING_PRINCIPAL, ascending=False))
 
-    overall_report = overall.generate_report_per_date(df_investiments, investment_files)
+    overall_report = overall.generate_report_per_date(df_investiments)
     overall.print_report_per_date(overall_report)
 
     diversification_report_per_date = diversification.generate_report_per_date(overall_report)

--- a/reports/overall.py
+++ b/reports/overall.py
@@ -5,11 +5,11 @@ from logger import logger
 from marketplace import marketplace
 
 
-def generate_report_per_date(df_investiments, investment_files):
+def generate_report_per_date(df_investiments):
     overall_report = defaultdict(datetime.datetime)
-    for date in sorted({date for data_file in investment_files.values() for date in data_file}):
+    for date in sorted(df_investiments[marketplace.FILE_DATE].unique()):
         # Overall statistics
-        overall_group_by_date = df_investiments[df_investiments[marketplace.FILE_DATE] == pandas.Timestamp(date)]
+        overall_group_by_date = df_investiments[df_investiments[marketplace.FILE_DATE] == date]
         total_invested_by_date = overall_group_by_date[marketplace.OUTSTANDING_PRINCIPAL].sum()
         total_invested_parts = len(overall_group_by_date.index)
 
@@ -24,7 +24,7 @@ def generate_report_per_date(df_investiments, investment_files):
         overall_group_by_originator['Percentage'] = overall_group_by_originator[marketplace.OUTSTANDING_PRINCIPAL] / total_invested_by_date
 
         # It will be used in the diversification
-        overall_report[date] = {
+        overall_report[datetime.datetime.date(pandas.to_datetime(date))] = {
             'Data': overall_group_by_date,
             'DataByCountry': overall_group_by_country,
             'DataByLoanOriginator': overall_group_by_originator,

--- a/test/test_overall_reports.py
+++ b/test/test_overall_reports.py
@@ -10,25 +10,16 @@ def test_overall_generate_report_per_date():
         "Spain,Creamfinance,75.0,mintos,2020-11-30\n"\
         "Poland,Creditstar,10.0,mintos,2020-11-30\n"\
         "Spain,Creamfinance,75.0,mintos,2020-11-30\n"\
-        "Poland,Creditstar,15.0,mintos,2020-11-30\n"
+        "Poland,Creditstar,15.0,mintos,2020-11-30\n"\
+        "Spain,Creditstar,15.0,mintos,2021-06-30\n"
     )
     input_data_frame = pandas.read_csv(input_data, parse_dates=['Date'])
 
-    input_files = {
-        'mintos': {
-            datetime.date(2021, 6, 30): './data/mintos/20210630-current-investments.xlsx',
-            datetime.date(2020, 11, 30): './data/mintos/20201130-current-investments.xlsx'
-        },
-        'iuvo': {
-            datetime.date(2020, 11, 30): './data/iuvo/MyInvestments-20201130.xlsx',
-            datetime.date(2021, 6, 30): './data/iuvo/MyInvestments-20210630.xlsx'
-        }
-    }
-    overall_report_per_date = overall.generate_report_per_date(input_data_frame, input_files)
+    overall_report_per_date = overall.generate_report_per_date(input_data_frame)
 
     expected_overall_report_per_date = {
         datetime.date(2020, 11, 30): {
-            'Data': input_data_frame,
+            'Data': input_data_frame[input_data_frame.index.isin([0,1,2,3,4])],
             'DataByCountry': pandas.DataFrame({
                 'Outstanding principal': {'Spain': 150.0, 'Poland': 75.0},
                 'Percentage': {'Spain': 0.666, 'Poland': 0.333}
@@ -45,23 +36,17 @@ def test_overall_generate_report_per_date():
             'NumberLoanParts': 5
         },
         datetime.date(2021, 6, 30): {
-            'Data': pandas.DataFrame({
-                'Country': {},
-                'Loan originator': {},
-                'Outstanding principal': {},
-                'Investment platform': {},
-                'Date': {}
-            }),
+            'Data': input_data_frame[input_data_frame.index.isin([5])],
             'DataByCountry': pandas.DataFrame({
-                'Outstanding principal': {},
-                'Percentage': {}
+                'Outstanding principal': {'Spain': 15.0},
+                'Percentage': {'Spain': 1.000}
             }),
             'DataByLoanOriginator': pandas.DataFrame({
-                'Outstanding principal': {},
-                'Percentage': {}
+                'Outstanding principal': {'Creditstar': 15.0},
+                'Percentage': {'Creditstar': 1.000}
             }),
-            'TotalInvestment': 0,
-            'NumberLoanParts': 0
+            'TotalInvestment': 15.0,
+            'NumberLoanParts': 1
         }
     }
 


### PR DESCRIPTION
I removed the dependency of the file lists from the overall report function. It is cleaner because passing the list of files does not make sense if the dataframe was aggregated before. 