### PR TITLE
Remove platform specific data dictionary

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -27,6 +27,7 @@ py_library(
         ":logger",
         "//marketplace",
         "//reports",
+        "//datacollection",
         requirement("pandas"),
         requirement("xlrd"),
         requirement("openpyxl"),

--- a/datacollection/BUILD
+++ b/datacollection/BUILD
@@ -1,0 +1,19 @@
+load("//tools/pytest:defs.bzl", "pytest_test")
+
+pytest_test(
+    name = "datacollection_test",
+    srcs = ["datacollection_test.py"],
+    deps = [
+        ":datacollection",
+        "//marketplace",
+    ],
+)
+
+py_library(
+    name = "datacollection",
+    srcs = [
+        "__init__.py",
+        "datacollection.py",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/datacollection/datacollection.py
+++ b/datacollection/datacollection.py
@@ -1,0 +1,19 @@
+import os
+import datetime
+
+def read_marketplace_files(data_directory, investment_platform):
+    marketplace_files = {}
+    for root, _, files in os.walk(os.path.join(data_directory, investment_platform.name)):
+        for investment_snapshot in files:
+            match = investment_platform.filename_regexp.search(investment_snapshot)
+            if match:
+                report_date = datetime.date.fromisoformat(f"{match.group('year')}-{match.group('month')}-{match.group('day')}")
+                marketplace_files[report_date] = os.path.join(root, investment_snapshot)
+    return marketplace_files
+
+
+def collect_investment_data(data_directory, investment_platforms):
+    data_files = {}
+    for investment_platform in investment_platforms:
+        data_files[investment_platform] = read_marketplace_files(data_directory, investment_platform)
+    return data_files

--- a/datacollection/datacollection_test.py
+++ b/datacollection/datacollection_test.py
@@ -1,0 +1,39 @@
+import datetime
+from unittest.mock import patch
+from marketplace import iuvo, mintos
+from datacollection.datacollection import read_marketplace_files
+
+@patch('datacollection.datacollection.os.walk')
+def test_read_marketplace_files_iuvo(os_walk):
+    os_walk.return_value = [
+        ('/iuvo', ('',), (
+            'MyInvestments-20201130.xlsx',
+            'MyInvestments-20201231.xlsx',
+            '20201130-current-investments.xlsx',
+            '20210630-current-investments.xlsx',
+            'OtherFile.xlsx',
+        ))
+    ]
+    output_data = {
+        datetime.date.fromisoformat("2020-11-30"): "/iuvo/MyInvestments-20201130.xlsx",
+        datetime.date.fromisoformat("2020-12-31"): "/iuvo/MyInvestments-20201231.xlsx",
+    }
+    assert output_data == read_marketplace_files("dummy/folder", iuvo.META_DATA)
+
+
+@patch('datacollection.datacollection.os.walk')
+def test_read_marketplace_files_mintos(os_walk):
+    os_walk.return_value = [
+        ('/mintos', ('',), (
+            'MyInvestments-20201130.xlsx',
+            'MyInvestments-20201231.xlsx',
+            '20201130-current-investments.xlsx',
+            '20210630-current-investments.xlsx',
+            'OtherFile.xlsx',
+        ))
+    ]
+    output_data = {
+        datetime.date.fromisoformat("2020-11-30"): "/mintos/20201130-current-investments.xlsx",
+        datetime.date.fromisoformat("2021-06-30"): "/mintos/20210630-current-investments.xlsx",
+    }
+    assert output_data == read_marketplace_files("dummy/folder", mintos.META_DATA)

--- a/marketplace/iuvo.py
+++ b/marketplace/iuvo.py
@@ -1,8 +1,8 @@
 import re
 from marketplace import marketplace
 
-MARKETPLACE_NAME = 'iuvo'
-MARKETPLACE_META_DATA = marketplace.Marketplace(
+META_DATA = marketplace.Marketplace(
+    name='iuvo',
     filename_regexp=re.compile(r'MyInvestments-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2}).xlsx'),
     display_name='IUVO',
     column_mapping={

--- a/marketplace/marketplace.py
+++ b/marketplace/marketplace.py
@@ -1,12 +1,19 @@
-from collections import namedtuple
+from typing import Any, NamedTuple
 
-Marketplace = namedtuple(
-    'Marketplace',
-    [
-        'filename_regexp', 'display_name', 'column_mapping',
-        'originators_rename', 'header', 'skipfooter'
-    ]
-)
+class Marketplace(NamedTuple):
+    """
+    Class that contains all static data needed to read information from a specific marketplace
+    """
+    name: str
+    filename_regexp: Any
+    display_name: str
+    column_mapping: 'dict[str, str]'
+    originators_rename: 'dict[str, str]'
+    header: int
+    skipfooter: int
+
+    def __hash__(self):
+        return hash(self.name)
 
 COUNTRY = 'Country'
 LOAN_ORIGINATOR = 'Loan originator'

--- a/marketplace/mintos.py
+++ b/marketplace/mintos.py
@@ -1,8 +1,8 @@
 import re
 from marketplace import marketplace
 
-MARKETPLACE_NAME = 'mintos'
-MARKETPLACE_META_DATA = marketplace.Marketplace(
+META_DATA = marketplace.Marketplace(
+    name='mintos',
     filename_regexp=re.compile(
         r'(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})-current-investments.xlsx'
     ),

--- a/p2p.py
+++ b/p2p.py
@@ -1,5 +1,4 @@
 import os
-import datetime
 import pandas
 from marketplace import mintos
 from marketplace import iuvo
@@ -7,6 +6,7 @@ from marketplace import marketplace
 from reports import diversification
 from reports import overall
 from logger import logger
+from datacollection.datacollection import collect_investment_data
 
 
 RELEVANT_COLUMNS = [marketplace.COUNTRY, marketplace.LOAN_ORIGINATOR, marketplace.OUTSTANDING_PRINCIPAL]
@@ -15,24 +15,6 @@ DATA_DIRECTORY = os.path.join('.', 'data')
 
 def get_latest_report_date(marketplace_files):
     return max(marketplace_files.keys())
-
-
-def read_marketplace_files(data_directory, investment_platform):
-    marketplace_files = {}
-    for root, _, files in os.walk(os.path.join(data_directory, investment_platform.name)):
-        for investment_snapshot in files:
-            match = investment_platform.filename_regexp.search(investment_snapshot)
-            if match:
-                report_date = datetime.date.fromisoformat(f"{match.group('year')}-{match.group('month')}-{match.group('day')}")
-                marketplace_files[report_date] = os.path.join(root, investment_snapshot)
-    return marketplace_files
-
-
-def collect_investment_data(data_directory, investment_platforms):
-    data_files = {}
-    for investment_platform in investment_platforms:
-        data_files[investment_platform] = read_marketplace_files(data_directory, investment_platform)
-    return data_files
 
 
 def aggregate_investment_data(investment_files):

--- a/test/test_p2p.py
+++ b/test/test_p2p.py
@@ -1,5 +1,7 @@
 import datetime
 from unittest.mock import patch
+from marketplace import mintos
+from marketplace import iuvo
 from p2p import get_latest_report_date, filter_investment_files_by_newest_date, \
     read_marketplace_files
 
@@ -31,7 +33,7 @@ def test_read_marketplace_files_iuvo(os_walk):
         datetime.date.fromisoformat("2020-11-30"): "/iuvo/MyInvestments-20201130.xlsx",
         datetime.date.fromisoformat("2020-12-31"): "/iuvo/MyInvestments-20201231.xlsx",
     }
-    assert output_data == read_marketplace_files("dummy/folder", "iuvo")
+    assert output_data == read_marketplace_files("dummy/folder", iuvo.META_DATA)
 
 
 @patch('p2p.os.walk')
@@ -49,7 +51,7 @@ def test_read_marketplace_files_mintos(os_walk):
         datetime.date.fromisoformat("2020-11-30"): "/mintos/20201130-current-investments.xlsx",
         datetime.date.fromisoformat("2021-06-30"): "/mintos/20210630-current-investments.xlsx",
     }
-    assert output_data == read_marketplace_files("dummy/folder", "mintos")
+    assert output_data == read_marketplace_files("dummy/folder", mintos.META_DATA)
 
 
 def test_filter_investment_files_by_newest_date():

--- a/test/test_p2p.py
+++ b/test/test_p2p.py
@@ -1,9 +1,5 @@
 import datetime
-from unittest.mock import patch
-from marketplace import mintos
-from marketplace import iuvo
-from p2p import get_latest_report_date, filter_investment_files_by_newest_date, \
-    read_marketplace_files
+from p2p import get_latest_report_date, filter_investment_files_by_newest_date
 
 
 def test_get_latest_report_date():
@@ -16,42 +12,6 @@ def test_get_latest_report_date():
         datetime.date.fromisoformat("2021-01-01") : "path6.xls",
     }
     assert datetime.date.fromisoformat("2021-12-01") == get_latest_report_date(input_data)
-
-
-@patch('p2p.os.walk')
-def test_read_marketplace_files_iuvo(os_walk):
-    os_walk.return_value = [
-        ('/iuvo', ('',), (
-            'MyInvestments-20201130.xlsx',
-            'MyInvestments-20201231.xlsx',
-            '20201130-current-investments.xlsx',
-            '20210630-current-investments.xlsx',
-            'OtherFile.xlsx',
-        ))
-    ]
-    output_data = {
-        datetime.date.fromisoformat("2020-11-30"): "/iuvo/MyInvestments-20201130.xlsx",
-        datetime.date.fromisoformat("2020-12-31"): "/iuvo/MyInvestments-20201231.xlsx",
-    }
-    assert output_data == read_marketplace_files("dummy/folder", iuvo.META_DATA)
-
-
-@patch('p2p.os.walk')
-def test_read_marketplace_files_mintos(os_walk):
-    os_walk.return_value = [
-        ('/mintos', ('',), (
-            'MyInvestments-20201130.xlsx',
-            'MyInvestments-20201231.xlsx',
-            '20201130-current-investments.xlsx',
-            '20210630-current-investments.xlsx',
-            'OtherFile.xlsx',
-        ))
-    ]
-    output_data = {
-        datetime.date.fromisoformat("2020-11-30"): "/mintos/20201130-current-investments.xlsx",
-        datetime.date.fromisoformat("2021-06-30"): "/mintos/20210630-current-investments.xlsx",
-    }
-    assert output_data == read_marketplace_files("dummy/folder", mintos.META_DATA)
 
 
 def test_filter_investment_files_by_newest_date():


### PR DESCRIPTION
The dictionary is not really needed, the name can be moved to the
marketplace class. This will help to not have a single point where
we need to depend on all platforms to do the data collection.