### PR TITLE
Change option of pylintrc to ignore imports

### DIFF
--- a/tools/pytest/.pylintrc
+++ b/tools/pytest/.pylintrc
@@ -477,7 +477,7 @@ ignore-comments=yes
 ignore-docstrings=yes
 
 # Ignore imports when computing similarities.
-ignore-imports=no
+ignore-imports=yes
 
 # Minimum lines number of a similarity.
 min-similarity-lines=4


### PR DESCRIPTION
This option prevents PR #53  because reports functions need to import the same libraries/modules. I propose to ignore similarities in the imports until we create a report class, which hopefully will mitigate this issue. 

This PR must be solved before #53.