### PR TITLE
Improve piecharts by adding valuable information at the center

### DIFF
--- a/dashboard/charts.py
+++ b/dashboard/charts.py
@@ -10,7 +10,8 @@ def piechart(investment_raw_data, group_by):
         investment_grouped_data,
         path=group_by,
         values='Outstanding principal',
-        labels='')
+        labels="",
+        maxdepth=3)
     fig.update_traces(
         textinfo="label+percent entry",
         hovertemplate = "%{value:,.2f}€")
@@ -21,14 +22,20 @@ def piechart(investment_raw_data, group_by):
 
 
 def piechart_OriginatorCountry(investment_raw_data):
+    modified_investment_raw_data = investment_raw_data.filter([marketplace.OUTSTANDING_PRINCIPAL, marketplace.LOAN_ORIGINATOR, marketplace.COUNTRY])
+    modified_investment_raw_data['Different Originators'] = f"{investment_raw_data[marketplace.OUTSTANDING_PRINCIPAL].sum():,.2f}€<br>"\
+        f"{len(set(investment_raw_data[marketplace.LOAN_ORIGINATOR].to_list()))} originators"
     return piechart(
-        investment_raw_data,
-        [marketplace.LOAN_ORIGINATOR, marketplace.COUNTRY]
+        modified_investment_raw_data,
+        ['Different Originators', marketplace.LOAN_ORIGINATOR, marketplace.COUNTRY]
     )
 
 
 def piechart_CountryOriginator(investment_raw_data):
+    modified_investment_raw_data = investment_raw_data.filter([marketplace.OUTSTANDING_PRINCIPAL, marketplace.COUNTRY, marketplace.LOAN_ORIGINATOR])
+    modified_investment_raw_data['Different Countries'] = f"{investment_raw_data[marketplace.OUTSTANDING_PRINCIPAL].sum():,.2f}€<br>"\
+        f"{len(set(investment_raw_data[marketplace.COUNTRY].to_list()))} countries"
     return piechart(
-        investment_raw_data,
-        [marketplace.COUNTRY, marketplace.LOAN_ORIGINATOR]
+        modified_investment_raw_data,
+        ['Different Countries', marketplace.COUNTRY, marketplace.LOAN_ORIGINATOR]
     )

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -21,7 +21,7 @@ external_stylesheets = [
 ]
 
 app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
-app.css.config.serve_locally = True
+app.title = 'p2p-lending'
 
 app.layout = dash.html.Div(
     [
@@ -31,12 +31,9 @@ app.layout = dash.html.Div(
                 dash.html.Div(
                     [
                         dash.html.H1(
-                            'P2P-LENDING',
+                            'P2P-LENDING - Monthly Snapshot',
                             style={'color':'#4b4b4b'},
                         ),
-                        dash.html.H2(
-                            'Monthly Report',
-                        )
                     ],
                     className='header',
                     style={
@@ -54,9 +51,9 @@ app.layout = dash.html.Div(
                                 ]),
                             style={
                                 'width': '100%',
-                                'height': '60px',
+                                'height': '40px',
                                 'textAlign': 'center',
-                                'lineHeight': '60px',
+                                'lineHeight': '40px',
                                 'margin': '10px',
                                 'box-shadow': 'rgba(3, 102, 214, 0.3) 0px 0px 0px 3px',
                                 },


### PR DESCRIPTION
I propose to add the total number of different parts (countries and loan originators)
and the total outstanding at the centre of the pie charts like the following image:

<img width="992" alt="Screenshot 2022-01-17 at 21 02 36" src="https://user-images.githubusercontent.com/19624445/149830999-004e0b53-6b49-481a-adad-10e9741a89d9.png">

